### PR TITLE
[JENKINS-43112] Add a Maven 3.3 installation (“apache-maven-3.3.9”) t…

### DIFF
--- a/src/main/java/org/jvnet/hudson/test/ToolInstallations.java
+++ b/src/main/java/org/jvnet/hudson/test/ToolInstallations.java
@@ -61,6 +61,14 @@ public class ToolInstallations {
         return m3;
     }
 
+    public static Maven.MavenInstallation configureMaven33() throws Exception {
+        Maven.MavenInstallation mvn = configureDefaultMaven("apache-maven-3.3.9", Maven.MavenInstallation.MAVEN_30);
+
+        Maven.MavenInstallation m33 = new Maven.MavenInstallation("apache-maven-3.3.9", mvn.getHome(), JenkinsRule.NO_PROPERTIES);
+        Jenkins.getInstance().getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(m33);
+        return m33;
+    }
+
     /**
      * Locates Maven2 and configure that as the only Maven in the system.
      */


### PR DESCRIPTION
[JENKINS-43112](https://issues.jenkins-ci.org/browse/JENKINS-43112) Add a Maven 3.3 installation (“apache-maven-3.3.9”) to the Jenkins Test Harness Tools.

We need Maven 3.3 for some tests of the [Pipeline Maven Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Maven+Plugin).