### PR TITLE
[JENKINS-34848] Download gradle instead of including it in the repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,24 @@ THE SOFTWARE.
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.3.0</version>
+                <executions>
+                    <execution>
+                        <id>download-gradle-2.13</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://services.gradle.org/distributions/gradle-2.13-bin.zip</url>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Amends https://github.com/jenkinsci/jenkins-test-harness-tools/pull/3 to avoid maintaining the file in the git repo.

@reviewbybees esp. @jglick 