### PR TITLE
add maven-3.9.1 to the available tool installations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,14 @@ THE SOFTWARE.
                                     <classifier>bin</classifier>
                                     <outputDirectory>${project.build.outputDirectory}</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.maven</groupId>
+                                    <artifactId>apache-maven</artifactId>
+                                    <version>3.9.1</version>
+                                    <type>zip</type>
+                                    <classifier>bin</classifier>
+                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Makes a more modern maven tool installer available.

This does not clean up the somewhat prehistoric versions.

the zip for maven 3.9.1 is 9MB in size which is much less than the 47MB of the single gradle plugin.

@jglick 

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
